### PR TITLE
Fix issue #5

### DIFF
--- a/flowio/flowdata.py
+++ b/flowio/flowdata.py
@@ -392,16 +392,14 @@ class FlowData(object):
         return channels
 
     def write_fcs(self, filename, extra=None, extra_non_standard=None):
-        pnn_labels = []
-        pns_labels = []
+        pnn_labels = [''] * len(self.channels)
+        pns_labels = [''] * len(self.channels)
 
-        for k in sorted(self.channels.keys()):
-            pnn_labels.append(self.channels[k]['PnN'])
+        for k in self.channels:
+            pnn_labels[int(k) - 1] = self.channels[k]['PnN']
 
             if 'PnS' in self.channels[k]:
-                pns_labels.append(self.channels[k]['PnS'])
-            else:
-                pns_labels.append('')
+                pns_labels[int(k) - 1] = self.channels[k]['PnS']
 
         if 'spill' in self.text:
             spill = self.text['spill']

--- a/flowio/tests/flowdata_tests.py
+++ b/flowio/tests/flowdata_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import io
+import tempfile
 from flowio import FlowData
 
 
@@ -35,6 +36,17 @@ class FlowDataTestCase(unittest.TestCase):
 
         self.assertIsInstance(fcs_export, FlowData)
         os.unlink(file_name)
+
+    def test_write_fcs_preserves_channels(self):
+        readdata = FlowData('examples/fcs_files/G11.fcs')
+        expected = readdata.channels
+
+        with tempfile.NamedTemporaryFile('w') as tmpfile:
+            readdata.write_fcs(tmpfile.name)
+            outdata = FlowData(tmpfile.name)
+            actually = outdata.channels
+
+            self.assertDictEqual(expected, actually)
 
     def test_issue_03(self):
         """

--- a/flowio/tests/flowdata_tests.py
+++ b/flowio/tests/flowdata_tests.py
@@ -7,6 +7,7 @@ from flowio import FlowData
 
 class FlowDataTestCase(unittest.TestCase):
     def setUp(self):
+        self.maxDiff = None
         self.flow_data = FlowData('examples/fcs_files/3FITC_4PE_004.fcs')
         self.flow_data_spill = FlowData('examples/fcs_files/100715.fcs')
         
@@ -38,10 +39,10 @@ class FlowDataTestCase(unittest.TestCase):
         os.unlink(file_name)
 
     def test_write_fcs_preserves_channels(self):
-        readdata = FlowData('examples/fcs_files/G11.fcs')
+        readdata = FlowData('examples/fcs_files/100715.fcs')
         expected = readdata.channels
 
-        with tempfile.NamedTemporaryFile('w') as tmpfile:
+        with tempfile.NamedTemporaryFile() as tmpfile:
             readdata.write_fcs(tmpfile.name)
             outdata = FlowData(tmpfile.name)
             actually = outdata.channels


### PR DESCRIPTION
This pull request provides one test case for issue #5  and applies a fix.

First commit: 

> This commit introduces a test which exposes a bug in
> FlowData.write_fcs, which means that channels are given the wrong
> index in the file created by write_fcs, if there are more than 9
> channels.
> 
> The issue is caused by the use of the sorted function in write_fcs to
> sort the keys of the channel dictionary. This results in a
> lexicographical ordering since the dictionary keys are strings (not
> integers).

Second commit:

> The mapping of channel index to channels are now preserved by
> write_fcs.
> 
> Small bug in the test case from previous commit, where PNS name is not
> correctly written by create_fcs. Don't know how to fix but pretty
> confident not related to write_fcs.
