### PR TITLE
This fixes flowdata.py not properly handling TemporaryFiles

### DIFF
--- a/flowio/flowdata.py
+++ b/flowio/flowdata.py
@@ -20,19 +20,14 @@ class FlowData(object):
     """
     Object representing a Flow Cytometry Standard (FCS) file
     """
-    def __init__(self, filename):
+    def __init__(self, filename_or_handle):
         """
         filename: an FCS filename
         """
-        if isinstance(filename, basestring):
-            self._fh = open(str(filename), 'rb')
-        elif isinstance(filename, IOBase):
-            self._fh = filename
+        if isinstance(filename_or_handle, basestring):
+            self._fh = open(str(filename_or_handle), 'rb')
         else:
-            raise TypeError(
-                "Filename must be a file path or a file handle " +
-                "(either 'file' type or io.IOBase")
-
+            self._fh = filename_or_handle
         self.cur_offset = 0
 
         # Get actual file size for sanity check of data section

--- a/flowio/tests/flowdata_tests.py
+++ b/flowio/tests/flowdata_tests.py
@@ -4,7 +4,6 @@ import os
 import io
 import tempfile
 from flowio import FlowData
-import pandas as pd
 
 
 class FlowDataTestCase(unittest.TestCase):

--- a/flowio/tests/flowdata_tests.py
+++ b/flowio/tests/flowdata_tests.py
@@ -1,8 +1,10 @@
+import shutil
 import unittest
 import os
 import io
 import tempfile
 from flowio import FlowData
+import pandas as pd
 
 
 class FlowDataTestCase(unittest.TestCase):
@@ -10,7 +12,7 @@ class FlowDataTestCase(unittest.TestCase):
         self.maxDiff = None
         self.flow_data = FlowData('examples/fcs_files/3FITC_4PE_004.fcs')
         self.flow_data_spill = FlowData('examples/fcs_files/100715.fcs')
-        
+
     def test_get_points(self):
         self.assertEqual(
             len(self.flow_data.events) / self.flow_data.channel_count,
@@ -25,9 +27,16 @@ class FlowDataTestCase(unittest.TestCase):
             mem_file = io.BytesIO(f.read())
             FlowData(mem_file)
 
+    def test_load_temp_file(self):
+        with tempfile.TemporaryFile() as tmpfile:
+            with open('examples/fcs_files/3FITC_4PE_004.fcs', 'r+b') as f:
+                shutil.copyfileobj(f, tmpfile)
+            tmpfile.seek(0)
+            out_data = FlowData(tmpfile)
+
     def test_load_non_file_input(self):
         non_file = object()
-        self.assertRaises(TypeError, FlowData, non_file)
+        self.assertRaises(AttributeError, FlowData, non_file)
 
     def test_write_fcs(self):
         file_name = 'flowio/tests/flowio_test_write_fcs.fcs'

--- a/flowio/tests/flowdata_tests.py
+++ b/flowio/tests/flowdata_tests.py
@@ -27,11 +27,12 @@ class FlowDataTestCase(unittest.TestCase):
             FlowData(mem_file)
 
     def test_load_temp_file(self):
-        with tempfile.TemporaryFile() as tmpfile:
+        with tempfile.TemporaryFile() as tmp_file:
             with open('examples/fcs_files/3FITC_4PE_004.fcs', 'r+b') as f:
-                shutil.copyfileobj(f, tmpfile)
-            tmpfile.seek(0)
-            out_data = FlowData(tmpfile)
+                shutil.copyfileobj(f, tmp_file)
+            tmp_file.seek(0)
+            out_data = FlowData(tmp_file)
+        self.assertIsInstance(out_data, FlowData)
 
     def test_load_non_file_input(self):
         non_file = object()


### PR DESCRIPTION
This is a fix for this issue: https://github.com/whitews/FlowKit/issues/59#issue-819535606
Includes a unit test for the fix and a change to an older unit test. Ultimately i think raising an AttributeException is the most informative/correct thing to do when a passed object doesn't implement a necessary method. 

Alternative fixes are to check that the passed filename_or_handle implements 1+ of the required methods (ie, seek, tell) and raise a type error, or wrap much of flowdata.py in a try and raise an TypeError. But both of these seem less elegant (checking that a function implements certain methods seems brittle and hard to understand for future contributors; and wrapping in try/raise makes it harder to find where an issue exists). 