### PR TITLE
Support parametrized optional FCS keywords

### DIFF
--- a/flowio/create_fcs.py
+++ b/flowio/create_fcs.py
@@ -62,16 +62,17 @@ def _build_text(
                 # skip it, these are allowed to be set by the user
                 continue
 
-            # Check for channel parameter keywords like:
+            # Check for channel parameter keywords that are handled in create_fcs:
             #   Pn(B, E, G, R, N, S)
             pnx_match = re.match(r'^(p)(\d+)([begrns])$', key)
             if pnx_match is not None:
                 # regardless of the channel parameter type, we'll skip it.
-                # All parameter metadata is handled separately
+                # These parameter keys are handled separately.
                 continue
 
             # check if the key is an FCS standard optional keyword
-            if key not in FCS_STANDARD_OPTIONAL_KEYWORDS:
+            pnx_match = re.match(r'^p\d+([dfloptv]|calibration)$', key)
+            if key not in FCS_STANDARD_OPTIONAL_KEYWORDS and pnx_match is None:
                 # save it for later, we'll put all the non-standard
                 # keys at the end
                 non_std_dict[key] = value

--- a/flowio/tests/fcs_write_tests.py
+++ b/flowio/tests/fcs_write_tests.py
@@ -202,6 +202,16 @@ class CreateFCSTestCase(unittest.TestCase):
             if k in FCS_STANDARD_KEYWORDS:
                 metadata_dict[k] = v
 
+        metadata_dict['$P1D'] = 'Linear,0,10'
+        metadata_dict['$P1F'] = '520LP'
+        metadata_dict['$P1L'] = '588'
+        metadata_dict['$P1O'] = '200'
+        metadata_dict['$P1P'] = '50'
+        metadata_dict['$P1T'] = 'PMT9524'
+        metadata_dict['$P1V'] = '250'
+        metadata_dict['$VOL'] = '120'
+        metadata_dict['$P1CALIBRATION'] = '1.234,MESF'
+
         export_file_path = "examples/fcs_files/test_fcs_export.fcs"
         fh = open(export_file_path, 'wb')
         create_fcs(fh, event_data, channel_names=pnn_labels, metadata_dict=metadata_dict)
@@ -210,10 +220,16 @@ class CreateFCSTestCase(unittest.TestCase):
         exported_flow_data = FlowData(export_file_path)
         os.unlink(export_file_path)
 
-        cyt_truth = 'Main Aria (FACSAria)'
-        cyt_value = exported_flow_data.text['cyt']
-
-        self.assertEqual(cyt_value, cyt_truth)
+        self.assertEqual(exported_flow_data.text['cyt'], 'Main Aria (FACSAria)')
+        self.assertEqual(exported_flow_data.text['p1d'], 'Linear,0,10')
+        self.assertEqual(exported_flow_data.text['p1f'], '520LP')
+        self.assertEqual(exported_flow_data.text['p1l'], '588')
+        self.assertEqual(exported_flow_data.text['p1o'], '200')
+        self.assertEqual(exported_flow_data.text['p1p'], '50')
+        self.assertEqual(exported_flow_data.text['p1t'], 'PMT9524')
+        self.assertEqual(exported_flow_data.text['p1v'], '250')
+        self.assertEqual(exported_flow_data.text['vol'], '120')
+        self.assertEqual(exported_flow_data.text['p1calibration'], '1.234,MESF')
 
     def test_create_fcs_with_non_std_metadata(self):
         event_data = self.flow_data.events


### PR DESCRIPTION
Adds support for setting `$Pn[DFLOPTV]` and `$PnCALIBRATION`. Skips the deprecated keywords (`$Gn*`, `$PKn`, `$PKNn`) and the rarely used ones (`$RnI`, `$RnW`, `$CSVnFLAG`).

FlowKit test run: https://github.com/primitybio/FlowIO/actions/runs/3130423878

---

Last PR for now. There are a few other changes I'd consider, but none are pressing:
- Don't upper-case all keys. Some importers are erroneously case-sensitive, so this can break those. Mixed case can also be easier to read as a human (things like `P2DetectorName`).
- Use a different delimiter than `/` since that's also found in file paths and the source of many invalid FCS files.
- Allow zero-length files. They're valid and sometimes useful.