### PR TITLE
Read multiple datasets from one file

### DIFF
--- a/flowio/__init__.py
+++ b/flowio/__init__.py
@@ -1,3 +1,4 @@
 from .flowdata import FlowData
 from .create_fcs import create_fcs
+from .utility import read_multiple_flowframes
 from ._version import __version__

--- a/flowio/exceptions.py
+++ b/flowio/exceptions.py
@@ -27,3 +27,10 @@ class DataOffsetDiscrepancyError(FCSParsingError):
     offsets for the DATA section.
     """
     pass
+
+class MultipleFramesDetectedError(FlowIOException):
+    """
+    Raised if a given FCS file contains more then one dataset, indicated by 
+    'nextdata' keyword.
+    """
+    pass

--- a/flowio/tests/__init__.py
+++ b/flowio/tests/__init__.py
@@ -3,6 +3,7 @@ import unittest
 from .flowdata_tests import FlowDataTestCase
 from .flowdata_lmd_tests import FlowDataLMDTestCase
 from .fcs_write_tests import CreateFCSTestCase
+from .read_multiple_datasets_tests import  MultipleDatasetsTestCase
 
 
 if __name__ == "__main__":

--- a/flowio/tests/flowdata_lmd_tests.py
+++ b/flowio/tests/flowdata_lmd_tests.py
@@ -8,7 +8,9 @@ class FlowDataLMDTestCase(unittest.TestCase):
     def setUp(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            self.flow_data = FlowData('examples/fcs_files/coulter.lmd', ignore_offset_error=True)
+            self.flow_data = FlowData('examples/fcs_files/coulter.lmd', 
+                                      ignore_offset_error=True,
+                                      multiframe_offset=0,)
         
     def test_event_count(self):
         self.assertEqual(
@@ -20,4 +22,5 @@ class FlowDataLMDTestCase(unittest.TestCase):
         self.assertEqual(self.flow_data.text['cyt'], 'Cytomics FC 500')
 
     def test_fail_data_offset_error(self):
-        self.assertRaises(FCSParsingError, FlowData, 'examples/fcs_files/coulter.lmd')
+        with self.assertRaises(FCSParsingError):     
+            FlowData('examples/fcs_files/coulter.lmd', multiframe_offset=0)

--- a/flowio/tests/read_multiple_datasets_tests.py
+++ b/flowio/tests/read_multiple_datasets_tests.py
@@ -1,0 +1,33 @@
+import unittest
+from flowio.exceptions import MultipleFramesDetectedError
+from flowio.flowdata import FlowData
+from flowio.utility import read_multiple_flowframes
+
+class MultipleDatasetsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.file = "examples/fcs_files/coulter.lmd"
+        self.amount_datasets = 2
+        self.channel_count = 8
+        self.event_count = 18110
+
+    def test_raise_error(self):
+        with self.assertRaises(MultipleFramesDetectedError):
+            FlowData(self.file)
+
+    def test_read_multiple_flowframes(self):
+        frames = read_multiple_flowframes(self.file, ignore_offset_error=True)
+
+        self.assertEqual(len(frames), 2)
+        self.assertIsInstance(frames[0], FlowData)
+        self.assertIsInstance(frames[1], FlowData)
+
+        self.assertEqual(frames[0].header["version"], "2.0")
+        self.assertEqual(frames[1].header["version"], "3.0")
+
+        self.assertEqual(frames[0].channel_count, self.channel_count)
+        self.assertEqual(frames[1].channel_count, self.channel_count)
+
+        self.assertEqual(frames[0].event_count, self.event_count)
+        self.assertEqual(frames[1].event_count, self.event_count)
+
+

--- a/flowio/utility.py
+++ b/flowio/utility.py
@@ -1,0 +1,39 @@
+from .flowdata import FlowData
+
+def read_multiple_flowframes(filename_or_handle,
+                             ignore_offset_error=False,
+                             ignore_offset_discrepancy=False,
+                             use_header_offsets=False,
+                             only_text=False,):
+    """
+    Utility function for reading all datasets contained in an fcs/lmd file.
+
+
+    :param filename_or_handle: a path string or a file handle for an FCS file
+    :param ignore_offset_error: option to ignore data offset error (see above note), default is False
+    :param ignore_offset_discrepancy: option to ignore discrepancy between the HEADER
+        and TEXT values for the DATA byte offset location, default is False
+    :param use_header_offsets: use the HEADER section for the data offset locations, default is False.
+        Setting this option to True also suppresses an error in cases of an offset discrepancy.
+    :param only_text: option to only read the "text" segment of the FCS file without loading event data,
+        default is False
+
+    :return: List of FlowData instances for each found dataset
+    """
+    frames = []
+    nextdata_offset = 0
+    while True:
+        frame = FlowData(filename_or_handle, 
+                         ignore_offset_error, 
+                         ignore_offset_discrepancy, 
+                         use_header_offsets, 
+                         only_text, 
+                         multiframe_offset=nextdata_offset)
+        frames.append(frame)
+        nextdata = int(frame.text["nextdata"])
+        if nextdata == 0:
+            return frames
+        nextdata_offset += nextdata
+        
+
+     


### PR DESCRIPTION
This will add a utility function to read all frames contained in a single `.fcs` or `.lmd ` file, see [issue](https://github.com/whitews/FlowIO/issues/15).
If such a file is opened with `FlowData()` a `MultipleFramesDetectedError` exception is thrown, so any tools can indicate that they should use `flowio.utility.read_multiple_flowframes()` in order to get all contained frames in a list.