### PR TITLE
Allow for creation of empty FCS files

### DIFF
--- a/flowio/create_fcs.py
+++ b/flowio/create_fcs.py
@@ -145,11 +145,6 @@ def create_fcs(
 
     n_points = len(event_data)
 
-    if n_points == 0:
-        raise ValueError(
-            "'event_data' array provided was empty"
-        )
-
     if not n_points % n_channels == 0:
         raise ValueError(
             "Number of data points is not a multiple of the number of channels"

--- a/flowio/tests/fcs_write_tests.py
+++ b/flowio/tests/fcs_write_tests.py
@@ -376,3 +376,28 @@ class CreateFCSTestCase(unittest.TestCase):
         os.unlink(export_file_path)
 
         self.assertEqual(flow_data.events[0], exported_flow_data.events[0])
+
+    def test_create_and_read_empty_fcs(self):
+        event_data = []
+        pnn_labels = [v["PnN"] for k, v in self.flow_data.channels.items()]
+        pns_labels = [v["PnS"] for k, v in self.flow_data.channels.items()]
+
+        metadata_dict = {"p9g": "2"}
+
+        export_file_path = "examples/fcs_files/test_fcs_export_empty.fcs"
+        with open(export_file_path, "wb") as export_file:
+            create_fcs(
+                export_file,
+                event_data,
+                channel_names=pnn_labels,
+                opt_channel_names=pns_labels,
+                metadata_dict=metadata_dict,
+            )
+
+        exported_flow_data = FlowData(export_file_path)
+        os.unlink(export_file_path)
+
+        self.assertIsInstance(exported_flow_data, FlowData)
+        self.assertEqual(len(exported_flow_data.events), 0)
+        self.assertEqual(exported_flow_data.channels, self.flow_data.channels)
+        self.assertEqual(exported_flow_data.text["p9g"], "2")


### PR DESCRIPTION
Hey,

Thank you for providing this lightweight tool. I have some use-cases where I need to perform filtering on an FCS file, which can result in an empty `event_data` array. Typically, this would raise a `ValueError`. However, by removing a couple of lines, I can still write the file to disk while retaining the metadata. Maybe you could drop this as I haven't noticed any problems with the created files.
