### PR TITLE
Ignore NaN reagents in create_fcs

### DIFF
--- a/src/flowio/create_fcs.py
+++ b/src/flowio/create_fcs.py
@@ -242,7 +242,9 @@ def create_fcs(
         # PnS - optional channel label
         if opt_channel_names is not None:
             # cannot have zero-length values in FCS keyword values
-            if opt_channel_names[i] not in [None, '']:
+            # equality test omits NaNs (result from "None" and "" in Pandas indices)
+            opt_channel_name = opt_channel_names[i]
+            if opt_channel_name not in [None, ''] and opt_channel_name == opt_channel_name:
                 text['P%dS' % chan_num] = opt_channel_names[i]
 
     # Calculate initial text size, but it's tricky b/c the text contains the

--- a/tests/test_fcs_write.py
+++ b/tests/test_fcs_write.py
@@ -193,6 +193,26 @@ class CreateFCSTestCase(unittest.TestCase):
 
         self.assertEqual(p5s_label_value, p5s_label_truth)
 
+    def test_create_fcs_with_opt_channel_labels_none(self):
+        event_data = self.flow_data.events
+        channel_names = self.flow_data.channels
+        pnn_labels = [v['PnN'] for k, v in channel_names.items()]
+        pns_labels = [v['PnS'] for k, v in channel_names.items()]
+        pns_labels[0] = None
+        pns_labels[1] = float("nan")
+        pns_labels[2] = ""
+
+        export_file_path = "examples/fcs_files/test_fcs_export.fcs"
+        with open(export_file_path, 'wb') as fh:
+            create_fcs(fh, event_data, channel_names=pnn_labels, opt_channel_names=pns_labels)
+
+        exported_flow_data = FlowData(export_file_path)
+        os.unlink(export_file_path)
+
+        self.assertNotIn("p1s", exported_flow_data.text)
+        self.assertNotIn("p2s", exported_flow_data.text)
+        self.assertNotIn("p3s", exported_flow_data.text)
+
     def test_create_fcs_with_std_metadata(self):
         event_data = self.flow_data.events
         channel_names = self.flow_data.channels


### PR DESCRIPTION
"None" and "" in Pandas indices become NaNs, which causes problems here when writing FCS files.