### PR TITLE
Support Posix Paths

### DIFF
--- a/.github/workflows/test_base.yml
+++ b/.github/workflows/test_base.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test_flowkit_develop.yml
+++ b/.github/workflows/test_flowkit_develop.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     steps:
       - name: Setup Python

--- a/.github/workflows/test_flowkit_master.yml
+++ b/.github/workflows/test_flowkit_master.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     steps:
       - name: Setup Python

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.12"
 
 python:
   install:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,11 @@ authors = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.7"
 ]
 
 [tool.setuptools.dynamic]

--- a/src/flowio/flowdata.py
+++ b/src/flowio/flowdata.py
@@ -7,6 +7,7 @@ import re
 from functools import reduce
 from .create_fcs import create_fcs
 from .exceptions import FCSParsingError, DataOffsetDiscrepancyError, MultipleDataSetsError
+from pathlib import Path
 
 try:
     # noinspection PyUnresolvedReferences, PyUnboundLocalVariable
@@ -78,17 +79,17 @@ class FlowData(object):
             only_text=False,
             nextdata_offset=None,
     ):
-        if isinstance(filename_or_handle, basestring):
+        if isinstance(filename_or_handle, (str, Path)):
             self._fh = open(str(filename_or_handle), 'rb')
         else:
             self._fh = filename_or_handle
 
-        current_offset = nextdata_offset if nextdata_offset else 0
+        current_offset = nextdata_offset or 0
 
         self._ignore_offset = ignore_offset_error
 
         try:
-            unused_path, self.name = os.path.split(self._fh.name)
+            self.name = Path(self._fh.name).name
         except (AttributeError, TypeError):
             self.name = 'InMemoryFile'
 


### PR DESCRIPTION
Should hopefully prevent errors such as the following:

```
lamindb/core/loaders.py:56: in load_fcs
    return readfcs.read(*args, **kwargs)
/opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/site-packages/readfcs/_core.py:250: in read
    fcsfile = ReadFCS(filepath)
/opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/site-packages/readfcs/_core.py:98: in __init__
    self._flow_data = flowio.read_multiple_data_sets(filepath)[data_set]
/opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/site-packages/flowio/utils.py:47: in read_multiple_data_sets
    fd = FlowData(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = FlowData(example.fcs), filename_or_handle = PosixPath('example.fcs')
ignore_offset_error = False, ignore_offset_discrepancy = False
use_header_offsets = False, only_text = False, nextdata_offset = 0

    def __init__(
            self,
            filename_or_handle,
            ignore_offset_error=False,
            ignore_offset_discrepancy=False,
            use_header_offsets=False,
            only_text=False,
            nextdata_offset=None,
    ):
        if isinstance(filename_or_handle, basestring):
            self._fh = open(str(filename_or_handle), 'rb')
        else:
            self._fh = filename_or_handle
    
        current_offset = nextdata_offset if nextdata_offset else 0
    
        self._ignore_offset = ignore_offset_error
    
        try:
            unused_path, self.name = os.path.split(self._fh.name)
        except (AttributeError, TypeError):
            self.name = 'InMemoryFile'
    
        # Get actual file size for sanity check of data section
>       self._fh.seek(0, os.SEEK_END)
E       AttributeError: 'PosixPath' object has no attribute 'seek'
```

I also updated the CI a bit because even Python 3.8 is already EOL with 3.9 soon to follow.